### PR TITLE
An error occurred in "transformFields"

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -23,6 +23,9 @@ const defaultRegex = ({ baseUrl }) =>
  * String replacement with async callback
  */
 const replaceAsync = async (str, regex, asyncFn) => {
+  if(typeof str != "string"){
+    return '';
+  }
   const promises = []
   str.replace(regex, (match, ...args) => {
     const promise = asyncFn(match, ...args)


### PR DESCRIPTION
If the target of "transformFields" is something other than "string", for example null, an error will occur.
Fixed to return an empty string when the target is other than "string".